### PR TITLE
fix: edge case bugs in settings/save, Math.max, and event deletion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -372,11 +372,10 @@ const defaultHandler = {
       if (!session) return new Response("Session expired", { status: 401 });
 
       const body = await request.formData();
-      const athleteId = body.get("athleteId") as string;
-      const apiKey = body.get("apiKey") as string;
+      const athleteId = ((body.get("athleteId") as string | null) ?? "").trim();
+      const apiKey = ((body.get("apiKey") as string | null) ?? "").trim();
 
-      const valid = await validateIntervalsCredentials(athleteId, apiKey);
-      if (!valid) {
+      if (!athleteId) {
         return new Response(
           `<!DOCTYPE html><html><head>
             <meta charset="utf-8">
@@ -384,8 +383,8 @@ const defaultHandler = {
             <style>${PAGE_CSS}</style>
           </head><body>
             <div class="card">
-              <h1>Invalid credentials</h1>
-              <p class="error">The athlete ID or API key you entered is incorrect. Please check your <a href="https://intervals.icu/settings" target="_blank" rel="noopener">intervals.icu settings</a> and try again.</p>
+              <h1>Missing athlete ID</h1>
+              <p class="error">Athlete ID is required.</p>
               <a href="/settings" class="btn-primary" style="display:inline-block;text-decoration:none">Try again</a>
             </div>
           </body></html>`,
@@ -393,10 +392,77 @@ const defaultHandler = {
         );
       }
 
-      const { encryptedApiKey, iv } = await encryptApiKey(apiKey, session.username, env.CREDENTIALS_MASTER_KEY);
+      let encResult: { encryptedApiKey: string; iv: string };
+
+      if (apiKey) {
+        // New API key provided — validate and encrypt
+        const valid = await validateIntervalsCredentials(athleteId, apiKey);
+        if (!valid) {
+          return new Response(
+            `<!DOCTYPE html><html><head>
+              <meta charset="utf-8">
+              <title>intervals.icu Settings</title>
+              <style>${PAGE_CSS}</style>
+            </head><body>
+              <div class="card">
+                <h1>Invalid credentials</h1>
+                <p class="error">The athlete ID or API key you entered is incorrect. Please check your <a href="https://intervals.icu/settings" target="_blank" rel="noopener">intervals.icu settings</a> and try again.</p>
+                <a href="/settings" class="btn-primary" style="display:inline-block;text-decoration:none">Try again</a>
+              </div>
+            </body></html>`,
+            { status: 400, headers: { "Content-Type": "text/html; charset=utf-8", "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'" } }
+          );
+        }
+        encResult = await encryptApiKey(apiKey, session.username, env.CREDENTIALS_MASTER_KEY);
+      } else {
+        // No API key — keep existing encrypted key
+        const existingCreds = await env.OAUTH_KV.get(`credentials:${session.username}`, "json") as {
+          athleteId: string; encryptedApiKey: string; iv: string;
+        } | null;
+        if (!existingCreds) {
+          return new Response(
+            `<!DOCTYPE html><html><head>
+              <meta charset="utf-8">
+              <title>intervals.icu Settings</title>
+              <style>${PAGE_CSS}</style>
+            </head><body>
+              <div class="card">
+                <h1>API key required</h1>
+                <p class="error">No existing credentials found. Please provide an API key.</p>
+                <a href="/settings" class="btn-primary" style="display:inline-block;text-decoration:none">Try again</a>
+              </div>
+            </body></html>`,
+            { status: 400, headers: { "Content-Type": "text/html; charset=utf-8", "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'" } }
+          );
+        }
+        // Validate existing key works with the (possibly new) athlete ID
+        const existingApiKey = await decryptApiKey(
+          existingCreds.encryptedApiKey, existingCreds.iv,
+          session.username, env.CREDENTIALS_MASTER_KEY
+        );
+        const valid = await validateIntervalsCredentials(athleteId, existingApiKey);
+        if (!valid) {
+          return new Response(
+            `<!DOCTYPE html><html><head>
+              <meta charset="utf-8">
+              <title>intervals.icu Settings</title>
+              <style>${PAGE_CSS}</style>
+            </head><body>
+              <div class="card">
+                <h1>Invalid credentials</h1>
+                <p class="error">Your existing API key does not work with the provided athlete ID. Please provide a new API key.</p>
+                <a href="/settings" class="btn-primary" style="display:inline-block;text-decoration:none">Try again</a>
+              </div>
+            </body></html>`,
+            { status: 400, headers: { "Content-Type": "text/html; charset=utf-8", "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'" } }
+          );
+        }
+        encResult = { encryptedApiKey: existingCreds.encryptedApiKey, iv: existingCreds.iv };
+      }
+
       await env.OAUTH_KV.put(
         `credentials:${session.username}`,
-        JSON.stringify({ athleteId, encryptedApiKey, iv })
+        JSON.stringify({ athleteId, encryptedApiKey: encResult.encryptedApiKey, iv: encResult.iv })
       );
 
       return new Response(

--- a/src/tools/activities.ts
+++ b/src/tools/activities.ts
@@ -159,7 +159,7 @@ export function registerActivityTools(server: McpServer, client: IntervalsClient
 
         const timeStream = streams.find(s => s.type === "time");
         const timeData = (timeStream?.data as number[]) ?? [];
-        const total = Math.max(...streams.map(s => ((s.data as unknown[]) ?? []).length));
+        const total = Math.max(0, ...streams.map(s => ((s.data as unknown[]) ?? []).length));
         const sampleIndices = computeSampleIndices(timeData, total, interval_seconds);
 
         const output: Record<string, unknown> = {};

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -72,6 +72,15 @@ export function registerEventTools(server: McpServer, client: IntervalsClient): 
           `/athlete/${client.athleteId}/events`,
           { oldest: start_date, newest: end_date }
         );
+        if (!events?.length) {
+          return { content: [{ type: "text" as const, text: "No events found in the specified date range." }] };
+        }
+
+        const TRUNCATION_BOUNDARIES = [100, 200, 500, 1000];
+        const truncationWarning = TRUNCATION_BOUNDARIES.includes(events.length)
+          ? ` Warning: exactly ${events.length} events returned — the API may have truncated results. Consider using a narrower date range.`
+          : "";
+
         let deleted = 0;
         const failed: unknown[] = [];
         await Promise.all(events.map(async e => {
@@ -82,7 +91,10 @@ export function registerEventTools(server: McpServer, client: IntervalsClient): 
             failed.push(e.id);
           }
         }));
-        return { content: [{ type: "text" as const, text: `Deleted ${deleted} events. Failed: ${failed.length} (${failed.join(", ")})` }] };
+        let text = `Deleted ${deleted} events.`;
+        if (failed.length) text += ` Failed: ${failed.length} (${failed.join(", ")})`;
+        text += truncationWarning;
+        return { content: [{ type: "text" as const, text }] };
       } catch (e) {
         return { content: [{ type: "text" as const, text: `Error: ${e}` }] };
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { defaultHandler, apiHandler } from "../src/index";
+import { encryptApiKey } from "../src/crypto";
 
 // Minimal mock for env.OAUTH_PROVIDER
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -347,6 +348,74 @@ describe("defaultHandler /settings", () => {
       "credentials:testuser",
       expect.stringContaining("i999")
     );
+  });
+
+  it("POST /settings/save with blank athleteId returns 400", async () => {
+    const env = makeEnv({ CREDENTIALS_MASTER_KEY: "a".repeat(64) });
+    env.OAUTH_KV.get.mockResolvedValue({ username: "testuser" });
+
+    const req = new Request("https://mcp.example.com/settings/save", {
+      method: "POST",
+      body: new URLSearchParams({ athleteId: "", apiKey: "somekey" }),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: "settings_session=mytoken",
+      },
+    });
+    const res = await defaultHandler.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain("Missing athlete ID");
+  });
+
+  it("POST /settings/save with blank apiKey keeps existing credentials", async () => {
+    const masterKey = "a".repeat(64);
+    const env = makeEnv({ CREDENTIALS_MASTER_KEY: masterKey });
+    // Encrypt a real key so decryptApiKey succeeds
+    const encrypted = await encryptApiKey("existingkey", "testuser", masterKey);
+    // First get: session lookup; Second get: existing credentials
+    env.OAUTH_KV.get
+      .mockResolvedValueOnce({ username: "testuser" })
+      .mockResolvedValueOnce({ athleteId: "i123", encryptedApiKey: encrypted.encryptedApiKey, iv: encrypted.iv });
+    // validateIntervalsCredentials will call fetch
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    const req = new Request("https://mcp.example.com/settings/save", {
+      method: "POST",
+      body: new URLSearchParams({ athleteId: "i123", apiKey: "" }),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: "settings_session=mytoken",
+      },
+    });
+    const res = await defaultHandler.fetch(req, env);
+    expect(res.status).toBe(200);
+    // Should store the existing encrypted key, not re-encrypt
+    expect(env.OAUTH_KV.put).toHaveBeenCalledWith(
+      "credentials:testuser",
+      expect.stringContaining(encrypted.encryptedApiKey)
+    );
+  });
+
+  it("POST /settings/save with blank apiKey and no existing creds returns 400", async () => {
+    const env = makeEnv({ CREDENTIALS_MASTER_KEY: "a".repeat(64) });
+    // First get: session lookup; Second get: no existing credentials
+    env.OAUTH_KV.get
+      .mockResolvedValueOnce({ username: "testuser" })
+      .mockResolvedValueOnce(null);
+
+    const req = new Request("https://mcp.example.com/settings/save", {
+      method: "POST",
+      body: new URLSearchParams({ athleteId: "i123", apiKey: "" }),
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: "settings_session=mytoken",
+      },
+    });
+    const res = await defaultHandler.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain("API key required");
   });
 
   it("GET /settings with credentials shows disconnect form", async () => {


### PR DESCRIPTION
## Summary
- Add `Math.max(0, ...)` guard in activities.ts to prevent `-Infinity` when all stream data arrays are empty
- Validate `/settings/save` form inputs: require athleteId, support "leave blank to keep current" for API key by loading/decrypting existing credentials from KV
- Add null guard and API truncation warning to `delete_events_by_date_range`

## Test plan
- [x] 3 new tests for /settings/save validation (blank athleteId, blank apiKey keeps existing, blank apiKey no existing creds)
- [ ] Manual test of /settings/save with blank fields via browser
- [x] All 87 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)